### PR TITLE
Fixed '<g> </g>' becoming '<g></g>' and made beautification idempotent

### DIFF
--- a/pretty-data.js
+++ b/pretty-data.js
@@ -65,7 +65,7 @@ function pp() {
 
 pp.prototype.xml = function(text) {
 
-	var ar = text.replace(/>\s{0,}</g,"><")
+	var ar = text.replace(/>\s*<(?!\/)/g,"><")
 				 .replace(/</g,"~::~<")
 				 .replace(/xmlns\:/g,"~::~xmlns:")
 				 .replace(/xmlns\=/g,"~::~xmlns=")

--- a/pretty-data.js
+++ b/pretty-data.js
@@ -1,11 +1,11 @@
 /**
 * pretty-data - nodejs plugin to pretty-print or minify data in XML, JSON and CSS formats.
-*  
+*
 * Version - 0.40.0
 * Copyright (c) 2012 Vadim Kiryukhin
 * vkiryukhin @ gmail.com
 * http://www.eslinstructor.net/pretty-data/
-* 
+*
 * Dual licensed under the MIT and GPL licenses:
 *   http://www.opensource.org/licenses/mit-license.php
 *   http://www.gnu.org/licenses/gpl.html
@@ -15,20 +15,20 @@
 *	pd.css(data ) - pretty print CSS;
 *	pd.sql(data)  - pretty print SQL;
 *
-*	pd.xmlmin(data [, preserveComments] ) - minify XML; 
-*	pd.jsonmin(data)                      - minify JSON; 
-*	pd.cssmin(data [, preserveComments] ) - minify CSS; 
-*	pd.sqlmin(data)                       - minify SQL; 
+*	pd.xmlmin(data [, preserveComments] ) - minify XML;
+*	pd.jsonmin(data)                      - minify JSON;
+*	pd.cssmin(data [, preserveComments] ) - minify CSS;
+*	pd.sqlmin(data)                       - minify SQL;
 *
 * PARAMETERS:
 *
 *	@data  			- String; XML, JSON, CSS or SQL text to beautify;
-* 	@preserveComments	- Bool (optional, used in minxml and mincss only); 
-*				  Set this flag to true to prevent removing comments from @text; 
+* 	@preserveComments	- Bool (optional, used in minxml and mincss only);
+*				  Set this flag to true to prevent removing comments from @text;
 *	@Return 		- String;
-*	
+*
 * USAGE:
-*	
+*
 *	var pd  = require('pretty-data').pd;
 *
 *	var xml_pp   = pd.xml(xml_text);
@@ -56,11 +56,11 @@ function pp() {
 
 	// initialize array with shifts //
 	for(ix=0;ix<maxdeep;ix++){
-		this.shift.push(this.shift[ix]+this.step); 
+		this.shift.push(this.shift[ix]+this.step);
 	}
 
-};	
-	
+};
+
 // ----------------------- XML section ----------------------------------------------------
 
 pp.prototype.xml = function(text) {
@@ -78,55 +78,55 @@ pp.prototype.xml = function(text) {
 
 		for(ix=0;ix<len;ix++) {
 			// start comment or <![CDATA[...]]> or <!DOCTYPE //
-			if(ar[ix].search(/<!/) > -1) { 
+			if(ar[ix].search(/<!/) > -1) {
 				str += this.shift[deep]+ar[ix];
-				inComment = true; 
+				inComment = true;
 				// end comment  or <![CDATA[...]]> //
-				if(ar[ix].search(/-->/) > -1 || ar[ix].search(/\]>/) > -1 || ar[ix].search(/!DOCTYPE/) > -1 ) { 
-					inComment = false; 
+				if(ar[ix].search(/-->/) > -1 || ar[ix].search(/\]>/) > -1 || ar[ix].search(/!DOCTYPE/) > -1 ) {
+					inComment = false;
 				}
-			} else 
+			} else
 			// end comment  or <![CDATA[...]]> //
-			if(ar[ix].search(/-->/) > -1 || ar[ix].search(/\]>/) > -1) { 
+			if(ar[ix].search(/-->/) > -1 || ar[ix].search(/\]>/) > -1) {
 				str += ar[ix];
-				inComment = false; 
-			} else 
+				inComment = false;
+			} else
 			// <elm></elm> //
 			if( /^<\w/.exec(ar[ix-1]) && /^<\/\w/.exec(ar[ix]) &&
-				/^<[\w:\-\.\,]+/.exec(ar[ix-1]) == /^<\/[\w:\-\.\,]+/.exec(ar[ix])[0].replace('/','')) { 
+				/^<[\w:\-\.\,]+/.exec(ar[ix-1]) == /^<\/[\w:\-\.\,]+/.exec(ar[ix])[0].replace('/','')) {
 				str += ar[ix];
 				if(!inComment) deep--;
 			} else
 			 // <elm> //
 			if(ar[ix].search(/<\w/) > -1 && ar[ix].search(/<\//) == -1 && ar[ix].search(/\/>/) == -1 ) {
 				str = !inComment ? str += this.shift[deep++]+ar[ix] : str += ar[ix];
-			} else 
+			} else
 			 // <elm>...</elm> //
 			if(ar[ix].search(/<\w/) > -1 && ar[ix].search(/<\//) > -1) {
 				str = !inComment ? str += this.shift[deep]+ar[ix] : str += ar[ix];
-			} else 
+			} else
 			// </elm> //
-			if(ar[ix].search(/<\//) > -1) { 
+			if(ar[ix].search(/<\//) > -1) {
 				str = !inComment ? str += this.shift[--deep]+ar[ix] : str += ar[ix];
-			} else 
+			} else
 			// <elm/> //
-			if(ar[ix].search(/\/>/) > -1 ) { 
+			if(ar[ix].search(/\/>/) > -1 ) {
 				str = !inComment ? str += this.shift[deep]+ar[ix] : str += ar[ix];
-			} else 
+			} else
 			// <? xml ... ?> //
-			if(ar[ix].search(/<\?/) > -1) { 
+			if(ar[ix].search(/<\?/) > -1) {
 				str += this.shift[deep]+ar[ix];
-			} else 
+			} else
 			// xmlns //
-			if( ar[ix].search(/xmlns\:/) > -1  || ar[ix].search(/xmlns\=/) > -1) { 
+			if( ar[ix].search(/xmlns\:/) > -1  || ar[ix].search(/xmlns\=/) > -1) {
 				str += this.shift[deep]+ar[ix];
-			} 
-			
+			}
+
 			else {
 				str += ar[ix];
 			}
 		}
-		
+
 	return  (str[0] == '\n') ? str.slice(1) : str;
 }
 
@@ -159,16 +159,16 @@ pp.prototype.css = function(text) {
 		deep = 0,
 		str = '',
 		ix = 0;
-		
+
 		for(ix=0;ix<len;ix++) {
 
-			if( /\{/.exec(ar[ix]))  { 
+			if( /\{/.exec(ar[ix]))  {
 				str += this.shift[deep++]+ar[ix];
-			} else 
-			if( /\}/.exec(ar[ix]))  { 
+			} else
+			if( /\}/.exec(ar[ix]))  {
 				str += this.shift[--deep]+ar[ix];
 			} else
-			if( /\*\\/.exec(ar[ix]))  { 
+			if( /\*\\/.exec(ar[ix]))  {
 				str += this.shift[deep]+ar[ix];
 			}
 			else {
@@ -219,8 +219,8 @@ function split_sql(str, tab) {
         //.replace(/\,/ig,",~::~"+tab+tab+"")
         .replace(/ ALL /ig," ALL ")
         .replace(/ AS /ig," AS ")
-        .replace(/ ASC /ig," ASC ") 
-        .replace(/ DESC /ig," DESC ") 
+        .replace(/ ASC /ig," ASC ")
+        .replace(/ DESC /ig," DESC ")
         .replace(/ DISTINCT /ig," DISTINCT ")
         .replace(/ EXISTS /ig," EXISTS ")
         .replace(/ NOT /ig," NOT ")
@@ -260,26 +260,26 @@ pp.prototype.sql = function(text) {
 
         parenthesisLevel = isSubquery(ar[ix], parenthesisLevel);
 
-        if( /\s{0,}\s{0,}SELECT\s{0,}/.exec(ar[ix]))  { 
+        if( /\s{0,}\s{0,}SELECT\s{0,}/.exec(ar[ix]))  {
             ar[ix] = ar[ix].replace(/\,/g,",\n"+tab+tab+"")
-        } 
+        }
 
-        if( /\s{0,}\(\s{0,}SELECT\s{0,}/.exec(ar[ix]))  { 
+        if( /\s{0,}\(\s{0,}SELECT\s{0,}/.exec(ar[ix]))  {
             deep++;
             str += this.shift[deep]+ar[ix];
-        } else 
-        if( /\'/.exec(ar[ix]) )  { 
+        } else
+        if( /\'/.exec(ar[ix]) )  {
             if(parenthesisLevel<1 && deep) {
                 deep--;
             }
             str += ar[ix];
         }
-        else  { 
+        else  {
             str += this.shift[deep]+ar[ix];
             if(parenthesisLevel<1 && deep) {
                 deep--;
             }
-        } 
+        }
     }
 
     str = str.replace(/^\n{1,}/,'').replace(/\n{1,}/g,"\n");
@@ -292,11 +292,11 @@ pp.prototype.xmlmin = function(text, preserveComments) {
 
 	var str = preserveComments ? text
 				   : text.replace(/\<![ \r\n\t]*(--([^\-]|[\r\n]|-[^\-])*--[ \r\n\t]*)\>/g,"");
-	return  str.replace(/>\s{0,}</g,"><"); 
+	return  str.replace(/>\s{0,}</g,"><");
 }
 
 pp.prototype.jsonmin = function(text) {
-								  
+
     return  text.replace(/\s{0,}\{\s{0,}/g,"{")
                 .replace(/\s{0,}\[$/g,"[")
                 .replace(/\[\s{0,}/g,"[")
@@ -310,11 +310,11 @@ pp.prototype.jsonmin = function(text) {
                 .replace(/:\s{0,}\[/g,':[')
                 .replace(/\,\s{0,}\[/g,',[')
                 .replace(/\,\s{2,}/g,', ')
-                .replace(/\]\s{0,},\s{0,}\[/g,'],[');   
+                .replace(/\]\s{0,},\s{0,}\[/g,'],[');
 }
 
 pp.prototype.cssmin = function(text, preserveComments) {
-	
+
 	var str = preserveComments ? text
 				   : text.replace(/\/\*([^*]|[\r\n]|(\*+([^*/]|[\r\n])))*\*+\//g,"") ;
 	return str.replace(/\s{1,}/g,' ')
@@ -323,7 +323,7 @@ pp.prototype.cssmin = function(text, preserveComments) {
 			  .replace(/\;\s{1,}/g,";")
 			  .replace(/\/\*\s{1,}/g,"/*")
 			  .replace(/\*\/\s{1,}/g,"*/");
-}	
+}
 
 pp.prototype.sqlmin = function(text) {
     return text.replace(/\s{1,}/g," ").replace(/\s{1,}\(/,"(").replace(/\s{1,}\)/,")");
@@ -331,7 +331,7 @@ pp.prototype.sqlmin = function(text) {
 
 // --------------------------------------------------------------------------------------------
 
-exports.pd= new pp;	
+exports.pd= new pp;
 
 
 

--- a/pretty-data.js
+++ b/pretty-data.js
@@ -66,6 +66,7 @@ function pp() {
 pp.prototype.xml = function(text) {
 
 	var ar = text.replace(/>\s*<(?!\/)/g,"><")
+				 .replace(/(\r\n|\n|\r)\s*/g, "")
 				 .replace(/</g,"~::~<")
 				 .replace(/xmlns\:/g,"~::~xmlns:")
 				 .replace(/xmlns\=/g,"~::~xmlns=")

--- a/test/test_xml.js
+++ b/test/test_xml.js
@@ -1,12 +1,14 @@
 
 var xml = '<?xml version="1.0" encoding="UTF-8" ?>      <!DOCTYPE foo SYSTEM "Foo.dtd"><a>          <b>bbb</b>   <!-- comment --><c/><d><soapenv:Envelope xmlns:soapenv="http://xxx" xmlns:xsd="http://yyy" xmlns:xsi="http://zzz"></soapenv>       </d><e>        <![CDATA[ <z></z> ]]></e><f><g> </g></f></a>',
     pp_xml  = require('../pretty-data').pd.xml(xml),
+    pp_xml2 = require('../pretty-data').pd.xml(pp_xml),
     pp_xmlmin_com  = require('../pretty-data').pd.xmlmin(xml,true),
     pp_xmlmin  = require('../pretty-data').pd.xmlmin(xml);
 
 console.log('\n==============================================================================\n');
 console.log('\n/*------- Original XML string: -------*/\n\n' + xml + '\n');
 console.log('\n/*------- Beautified XML -------------*/\n\n' + pp_xml  + '\n');
+console.log('\n/*------- Beautifing XML twice yields same result -----*/\n\n' + (pp_xml === pp_xml2)  + '\n');
 console.log('\n/*------- Minified XML with preserved comments: -------*/\n\n' + pp_xmlmin_com + '\n');
 console.log('\n/*------- Minified XML with deleted comments: ---------*/\n\n' + pp_xmlmin + '\n');
 console.log('\n===============================================================================\n');

--- a/test/test_xml.js
+++ b/test/test_xml.js
@@ -1,5 +1,5 @@
-	
-var xml = '<?xml version="1.0" encoding="UTF-8" ?>      <!DOCTYPE foo SYSTEM "Foo.dtd"><a>          <b>bbb</b>   <!-- comment --><c/><d><soapenv:Envelope xmlns:soapenv="http://xxx" xmlns:xsd="http://yyy" xmlns:xsi="http://zzz"></soapenv>       </d><e>        <![CDATA[ <z></z> ]]></e><f><g></g></f></a>',
+
+var xml = '<?xml version="1.0" encoding="UTF-8" ?>      <!DOCTYPE foo SYSTEM "Foo.dtd"><a>          <b>bbb</b>   <!-- comment --><c/><d><soapenv:Envelope xmlns:soapenv="http://xxx" xmlns:xsd="http://yyy" xmlns:xsi="http://zzz"></soapenv>       </d><e>        <![CDATA[ <z></z> ]]></e><f><g> </g></f></a>',
     pp_xml  = require('../pretty-data').pd.xml(xml),
     pp_xmlmin_com  = require('../pretty-data').pd.xmlmin(xml,true),
     pp_xmlmin  = require('../pretty-data').pd.xmlmin(xml);


### PR DESCRIPTION
Both fixes come with tests

Idempotence means that applying beautification more than once does not change the result. Before, running it twice on the test input yielded this

```xml
  <d>
    <soapenv:Envelope

      xmlns:soapenv="http://xxx"

      xmlns:xsd="http://yyy"

      xmlns:xsi="http://zzz">
    </soapenv>
  </d>
```