### PR TITLE
Fix incorrect handling of CDATA content. See #15.

### DIFF
--- a/pretty-data.js
+++ b/pretty-data.js
@@ -65,8 +65,7 @@ function pp() {
 
 pp.prototype.xml = function(text) {
 
-	var ar = text.replace(/>\s{0,}</g,"><")
-				 .replace(/</g,"~::~<")
+	var ar = text.replace(/</g,"~::~<")
 				 .replace(/xmlns\:/g,"~::~xmlns:")
 				 .replace(/xmlns\=/g,"~::~xmlns=")
 				 .split('~::~'),
@@ -115,7 +114,7 @@ pp.prototype.xml = function(text) {
 			} else 
 			// <? xml ... ?> //
 			if(ar[ix].search(/<\?/) > -1) { 
-				str += this.shift[deep]+ar[ix];
+				str =  !inComment ? str += this.shift[deep]+ar[ix] : str += ar[ix];
 			} else 
 			// xmlns //
 			if( ar[ix].search(/xmlns\:/) > -1  || ar[ix].search(/xmlns\=/) > -1) { 

--- a/test/test_xml.js
+++ b/test/test_xml.js
@@ -1,5 +1,5 @@
 	
-var xml = '<?xml version="1.0" encoding="UTF-8" ?>      <!DOCTYPE foo SYSTEM "Foo.dtd"><a>          <b>bbb</b>   <!-- comment --><c/><d><soapenv:Envelope xmlns:soapenv="http://xxx" xmlns:xsd="http://yyy" xmlns:xsi="http://zzz"></soapenv>       </d><e>        <![CDATA[ <z></z> ]]></e><f><g></g></f></a>',
+var xml = '<?xml version="1.0" encoding="UTF-8" ?>      <!DOCTYPE foo SYSTEM "Foo.dtd"><a>          <b>bbb</b>   <!-- comment --><c/><d><soapenv:Envelope xmlns:soapenv="http://xxx" xmlns:xsd="http://yyy" xmlns:xsi="http://zzz"></soapenv>       </d><e>        <![CDATA[ <?<z>    </z> ]]></e><f><g></g></f></a>',
     pp_xml  = require('../pretty-data').pd.xml(xml),
     pp_xmlmin_com  = require('../pretty-data').pd.xmlmin(xml,true),
     pp_xmlmin  = require('../pretty-data').pd.xmlmin(xml);


### PR DESCRIPTION
* Removed greedy space removal between elements (not sure if that can break anything).
* XML declaration `<?xml` won't format CDATA won't add new-line.


Changed test to contain:

```
<![CDATA[ <?<z>   </z> ]]>
```

That should display effect of both changes.