### PR TITLE
Switch to minify-xml for xmlmin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/package.json
+++ b/package.json
@@ -13,18 +13,21 @@
     "type": "git",
     "url": "http://github.com/vkiryukhin/pretty-data.git"
   },
-  "main":"./pretty-data",
+  "main": "./pretty-data",
   "keywords": [
-	"pretty print",
-	"beautify",
-	"minify",
-        "XML",
-	"JSON",
-	"CSS",
-        "SQL"
+    "pretty print",
+    "beautify",
+    "minify",
+    "XML",
+    "JSON",
+    "CSS",
+    "SQL"
   ],
   "license": "MIT",
   "engine": {
     "node": ">=0.4.9"
+  },
+  "dependencies": {
+    "minify-xml": "^2.1.0"
   }
 }

--- a/pretty-data.js
+++ b/pretty-data.js
@@ -15,24 +15,26 @@
 *	pd.css(data ) - pretty print CSS;
 *	pd.sql(data)  - pretty print SQL;
 *
-*	pd.xmlmin(data [, preserveComments] ) - minify XML;
-*	pd.jsonmin(data)                      - minify JSON;
-*	pd.cssmin(data [, preserveComments] ) - minify CSS;
-*	pd.sqlmin(data)                       - minify SQL;
+*	pd.xmlmin(data [, preserveComments, options] ) - minify XML;
+*	pd.jsonmin(data)                               - minify JSON;
+*	pd.cssmin(data [, preserveComments] )          - minify CSS;
+*	pd.sqlmin(data)                                - minify SQL;
 *
 * PARAMETERS:
 *
-*	@data  			- String; XML, JSON, CSS or SQL text to beautify;
-* 	@preserveComments	- Bool (optional, used in minxml and mincss only);
-*				  Set this flag to true to prevent removing comments from @text;
-*	@Return 		- String;
+*	@data			- String; XML, JSON, CSS or SQL text to beautify;
+* 	@preserveComments	- Bool (optional, used in xmlmin and cssmin only);
+*				  Set this flag to true to prevent removing comments from @data;
+*	@options		- Object (optional, used in xmlmin only);
+*				  Use this object to set additional flags flags;
+*	@Return			- String;
 *
 * USAGE:
 *
 *	var pd  = require('pretty-data').pd;
 *
 *	var xml_pp   = pd.xml(xml_text);
-*	var xml_min  = pd.xmlmin(xml_text [,true]);
+*	var xml_min  = pd.xmlmin(xml_text [, true, { removeWhitespaceBetweenTags: false }]);
 *	var json_pp  = pd.json(json_text);
 *	var json_min = pd.jsonmin(json_text);
 *	var css_pp   = pd.css(css_text);
@@ -285,11 +287,10 @@ pp.prototype.sql = function(text) {
 
 // ----------------------- min section ----------------------------------------------------
 
+const minifyXml = require("minify-xml").minify;
 pp.prototype.xmlmin = function(text, preserveComments) {
-
-	var str = preserveComments ? text
-				   : text.replace(/\<![ \r\n\t]*(--([^\-]|[\r\n]|-[^\-])*--[ \r\n\t]*)\>/g,"");
-	return  str.replace(/>\s{0,}</g,"><");
+	return minifyXml(text, typeof preserveComments === "boolean" ?
+		{ removeComments: !preserveComments } : preserveComments);
 };
 
 pp.prototype.jsonmin = function(text) {


### PR DESCRIPTION
I would like to get rid of the phun on my README.md [1]. pretty-data is
currently not minifying very much in regards to XML optimization. Thus
I would like to suggest, you could switch to my library minify-xml. It
is also based on simple regular expression replacements, thus it is fits
very well to your library. I also took your "between tags" and "comment"
regular expressions and adapted them.

This change is compatible to existing usages of your API. If
preserveComments is set, it will be forwarded to my library with the
same behaviour.

This is just a suggestion, but my library is optimizing many more things
in regards to XML such as removing unnecessary whitespace in attributes,
removing unused namespaces, collapsing empty elements. It also features
a better CDATA handling, as the way you did it could easily fail when
to be optimized things are part of CDATA.

[1] https://github.com/kristian/minify-xml#readme